### PR TITLE
Removed check for independent sponsor role on documents list

### DIFF
--- a/resources/views/documents/list.blade.php
+++ b/resources/views/documents/list.blade.php
@@ -8,52 +8,33 @@
 					<li class="active">{{ trans('messages.document') }}s</li>
 				</ol>
 			</div>
-			@if($loggedUser->hasRole('Independent Sponsor'))
-				<div class="col-md-8 admin-document-list">
-					<h2>{{ trans('messages.document') }}s</h2>
-					<ul>
-						@if($doc_count == 0)
-							<li>{{ trans('messages.nodocuments') }}</li>
-						@else
-							{{ trans('messages.indiedocs') }}:
-							@foreach($documents['independent'] as $doc)
-							<li>
-								<a href="{{ route('documents.edit', $doc->id) }}">{{ $doc->title }}</a>
-							</li>
-							@endforeach
-							@foreach($documents['group'] as $groupname=>$groupdocuments)
-								{{ trans('messages.group') }} '{{ $groupname }}'
-								@if(empty($groupdocuments))
-								<li>
-									{{ trans('messages.nogroupdocs') }}
-								</li>
-								@endif
-								@foreach($groupdocuments as $doc)
-								<li>
-									<a href="{{ route('documents.edit', $doc->id) }}">{{ $doc->title }}</a>
-								</li>
-								@endforeach
-							@endforeach
-						@endif
-					</ul>
-				</div>
-				<div class="col-md-4 admin-add-documents">
-					<h3>{{ trans('messages.createdoc') }}</h3>
-					<form action="{{ route('documents.create') }}" method="post" id="create-document-form">
-						{!! csrf_field() !!}
-						<div class="form-group">
-							<label for="title">{{ trans('messages.title') }}</label>
-							<input class="form-control" id="title" type="text" name="title" value="{{ old('title') }}" placeholder="{{ trans('messages.doctitle') }}">
-						</div>
-						<input class="btn" type="submit" name="createdoc" value="{{ trans('messages.createdoc') }}">
-					</form>
-				</div>
-			@else
-				<div class="col-md-12">
-					<h1>{{ trans('messages.document') }}s</h1>
-					<p>{{ trans('messages.besponsor') }} <a href="/documents/sponsor/request">{{ trans('messages.reqindepsponsor') }}</a></p>
-				</div>
-			@endif
+			<div class="col-md-8 admin-document-list">
+				<h2>{{ trans('messages.document') }}s</h2>
+        <br>
+				<ul>
+					@if($doc_count == 0)
+						<li>{{ trans('messages.nodocuments') }}</li>
+					@else
+						{{-- {{ trans('messages.indiedocs') }}: --}}
+						@foreach($documents as $doc)
+						<li>
+							<a href="{{ route('documents.edit', $doc->id) }}">{{ $doc->title }}</a>
+						</li>
+						@endforeach
+					@endif
+				</ul>
+			</div>
+			<div class="col-md-4 admin-add-documents">
+				<h3>{{ trans('messages.createdoc') }}</h3>
+				<form action="{{ route('documents.create') }}" method="post" id="create-document-form">
+					{!! csrf_field() !!}
+					<div class="form-group">
+						<label for="title">{{ trans('messages.title') }}</label>
+						<input class="form-control" id="title" type="text" name="title" value="{{ old('title') }}" placeholder="{{ trans('messages.doctitle') }}">
+					</div>
+					<input class="btn" type="submit" name="createdoc" value="{{ trans('messages.createdoc') }}">
+				</form>
+			</div>
 		</div>
 	</div>
 @stop


### PR DESCRIPTION
Removed check for independent sponsor role on documents list and removed separated lists independent and groups so the "My Documents" section lists all document that belong to the user regardless of his role or groups.