### PR TITLE
Minor fixes

### DIFF
--- a/app/Presenters/DocumentPresenter.php
+++ b/app/Presenters/DocumentPresenter.php
@@ -3,7 +3,10 @@
 namespace MXAbierto\Participa\Presenters;
 
 use GrahamCampbell\Markdown\Facades\Markdown;
+use Illuminate\Support\Facades\Log;
 use McCool\LaravelAutoPresenter\BasePresenter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
 
 /**
  * The document presenter class.
@@ -19,6 +22,14 @@ class DocumentPresenter extends BasePresenter
      */
     public function formatted_content()
     {
+        if (!$this->wrappedObject->content) {
+            $empty_content_log = new Logger('Documento sin contenido');
+            $empty_content_log->pushHandler(new StreamHandler(storage_path().'/logs/empty_content_log.log', Logger::INFO));
+            $empty_content_log->addInfo('El documento '.$this->wrappedObject->id.' - '.$this->wrappedObject->title.', no tiene registro relacionado en la tabla doc_contents');
+
+            return;
+        }
+
         return Markdown::convertToHtml($this->wrappedObject->content->content);
     }
 

--- a/resources/views/documents/edit.blade.php
+++ b/resources/views/documents/edit.blade.php
@@ -5,7 +5,7 @@
   <div class="row" ng-controller="DashboardEditorController" ng-init="init()">
     <div class="col-md-12">
       <ol class="breadcrumb">
-        <li><a href="{{ route('home') }}"><i class="icon icon-home"></i> {{ trans('messages.home')}}</a></li>
+        <li><a href="{{ route('home') }}" target="_self"><i class="icon icon-home"></i> {{ trans('messages.home')}}</a></li>
         <li><a href="{{ route('docs') }}" target="_self">{{ trans('messages.document') }}s</a></li>
         <li class="active">{{ $doc->title }}</li>
       </ol>

--- a/resources/views/documents/list.blade.php
+++ b/resources/views/documents/list.blade.php
@@ -4,7 +4,7 @@
 		<div class="row">
 			<div class="col-md-12">
 				<ol class="breadcrumb">
-					<li><a href="{{ route('home') }}"><i class="icon icon-home"></i> {{ trans('messages.home')}}</a></li>
+					<li><a href="{{ route('home') }}" target="_self"><i class="icon icon-home"></i> {{ trans('messages.home')}}</a></li>
 					<li class="active">{{ trans('messages.document') }}s</li>
 				</ol>
 			</div>

--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -13,9 +13,9 @@
     </div>
     <div class="collapse navbar-collapse" id="navbarMainCollapse">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="http://www.gob.mx/tramites">{{ trans('messages.services') }}</a></li>
-        <li><a href="http://www.gob.mx/presidencia">{{ trans('messages.government') }}</a></li>
-        <li><a href="http://www.gob.mx/participa">Participa</a></li>
+        <li><a target="_self" href="http://www.gob.mx/tramites">{{ trans('messages.services') }}</a></li>
+        <li><a target="_self" href="http://www.gob.mx/presidencia">{{ trans('messages.government') }}</a></li>
+        <li><a target="_self" href="http://www.gob.mx/participa">Participa</a></li>
         <li>
           <a href="http://www.gob.mx/busqueda">
             <i class="icon-search"></i>


### PR DESCRIPTION
Added target "_self" to navbar links and breadcrumbs to try to resolve #124

Added check on document presenter to avoid property of none object exception when document doesn't have doc_content. returns null and stores the document id on an empty_content_log.log file. 
Create new DocContent when trying to edit a document that doesn't have a doc_contents related record. Resolves #128