### PR TITLE
Added from address to password reminder email to solve error:

### DIFF
--- a/app/Http/Controllers/RemindersController.php
+++ b/app/Http/Controllers/RemindersController.php
@@ -38,6 +38,7 @@ class RemindersController extends AbstractController
         $this->validate($request, ['email' => 'required|email']);
 
         $response = Password::sendResetLink($request->only('email'), function (Message $message) {
+            $message->from(trans('messages.emailfrom'), trans('messages.emailfromname'));
             $message->subject(trans('messages.resetemailtitle'));
         });
 


### PR DESCRIPTION
Swift_TransportExceptionPOST /consulta/password/remind
Cannot send message without a sender address