### PR TITLE
Dockerfile Build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie
 RUN \
   # Install dependencies
   apt-get update && \
-  apt-get -y install \
+  apt-get -y --fix-missing install \
     nginx \
     php5-fpm \
     php5-cli \


### PR DESCRIPTION
Modified Dockerfile to set an option to prevent a broken build when some installation package is not found

<img width="1433" alt="screen shot 2015-09-10 at 15 13 50" src="https://cloud.githubusercontent.com/assets/1383865/9799713/9ebe99ce-57ce-11e5-9382-f8648a25207d.png">
