### PR TITLE
Added logged in user name to menu dropdown when user is logged in. Resolves #203

### DIFF
--- a/resources/views/partials/_nav-dropdown.blade.php
+++ b/resources/views/partials/_nav-dropdown.blade.php
@@ -1,6 +1,10 @@
 <div class="btn-group">
   <button type="button" class="btn btn-gray dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    Menú <span class="caret"></span>
+    @if($loggedUser)
+      <i class="icon icon-user"></i> &nbsp; {{ $loggedUser->name }} <span class="caret"></span>
+    @else
+      Menú <span class="caret"></span>
+    @endif
   </button>
   <ul class="dropdown-menu dropdown-menu-right">
     <li class="link-about">


### PR DESCRIPTION
Sin inicio de sesión:

<img width="992" alt="not logged in" src="https://cloud.githubusercontent.com/assets/4172905/10418522/1cbe7bde-7023-11e5-9a6d-8eddfad15288.png">

<img width="1011" alt="not logged in dropdown" src="https://cloud.githubusercontent.com/assets/4172905/10418521/158f9d16-7023-11e5-9981-b640224a8ff7.png">



Con inicio de sesión:

<img width="1000" alt="logged in" src="https://cloud.githubusercontent.com/assets/4172905/10418528/331ebf92-7023-11e5-8999-71ddc44b433b.png">

<img width="1051" alt="logged in dropdown" src="https://cloud.githubusercontent.com/assets/4172905/10418532/35872f62-7023-11e5-9221-b67080788881.png">




Para probar únicamente se necesita iniciar sesión

@rodowi que opinas así? Me parece que no hace falta algo más elaborado ya que el dropdown del menú igual solo contiene links que hacen referencia al usuario (A excepción del acerca de...)