### PR TITLE
HOTFIX - autores no se veían por error en lógica

### DIFF
--- a/resources/assets/js/controllers/Comment.js
+++ b/resources/assets/js/controllers/Comment.js
@@ -16,7 +16,7 @@ angular.module( 'madisonApp.controllers' )
             $scope.getDocComments( docId );
             $scope.user                 = user;
             $scope.doc                  = doc;
-            $scope.disableAuthor        = ( typeof disableAuthor !== 'undefined' );
+            $scope.disableAuthor        = ( typeof disableAuthor !== 'undefined' && disableAuthor == true );
             $scope.disableCommentAction = ( typeof disableCommentAction !== 'undefined' );
             $scope.getLayoutTexts();
         };


### PR DESCRIPTION
Si se pasaba disableAuthor=false como parámetro en el CommentsController, la condición regresaba true y no se veían los autores.

Probar
```javascript
typeof false !== 'undefined'
```

VS

```javascript
var param = false;
typeof param !== 'undefined' && param == true
>> false

param = true;
typeof param !== 'undefined' && param == true
>> true

param = undefined
typeof param !== 'undefined' && param == true
>> false
```